### PR TITLE
Thrifty minnow patch 011

### DIFF
--- a/_includes/official_resources.md
+++ b/_includes/official_resources.md
@@ -1,6 +1,6 @@
 Athough AEOn is community driven, official resources are considered to be those maintained by AEOn's initial developer, smooth.
 
-[Website](www.aeon.cash)
+[Website](https://www.aeon.cash)
 
 [GitHub](https://github.com/aeonix/aeon)
 

--- a/_includes/resources.md
+++ b/_includes/resources.md
@@ -1,6 +1,5 @@
-* [Reddit](www.reddit.com/r/aeon)
+* [Reddit](https://www.reddit.com/r/aeon)
 * [Twitter](https://twitter.com/AeonCoin)
 * [Medium](https://medium.com/@AEON_Community)
 * [Discord](https://discordapp.com/invite/TM8mEsx)
 * [Telegram](https://telegram.me/AEONgroup)
-* General CN stuff?


### PR DESCRIPTION
Without the leading "https:" there are 2 broken links on the new page layout.

Merging these in.