### PR TITLE
Update timeline for all current release data

### DIFF
--- a/information/timeline.md
+++ b/information/timeline.md
@@ -1,7 +1,7 @@
 Aeon Timeline
 -------------
 
-### 2014
+## 2014
 
 #### June
 
@@ -27,7 +27,7 @@ Aeon Timeline
   
   - [8] v0.8.8.6 Point release: fixes broken Windows static builds, multilang mnemonic bug fixes
 
-### 2015
+## 2015
 
 #### January
 
@@ -64,7 +64,33 @@ Various portability fixes (mostly from Monero), Small reduction to memory usage 
 
 #### December
 
-### 2016
+## 2016
+
+#### January
+
+#### Feburary 
+
+#### March
+
+#### April
+  
+#### May
+
+#### June
+
+#### July
+
+#### August
+
+#### September
+
+#### October
+
+#### November
+
+#### December
+
+## 2017
 
 #### January
 
@@ -84,31 +110,7 @@ Various portability fixes (mostly from Monero), Small reduction to memory usage 
 
   - [5] v0.9.11.0 Point release: Release resolves a deadlock issue introduced in 0.9.9.0 which caused the daemon to occasionally hang. 
   
-#### May
-
-#### June
-
-#### July
-
-#### August
-
-#### September
-
-#### October
-
-#### November
-
-#### December
-
-### 2017
-
-#### January
-
-#### Feburary 
-
-#### March
-
-#### April
+  - [23] v0.9.12.0 Point release: A future update (not yet scheduled) will begin enforcing the minimum relay fee equal to the current default fee, so nodes that have not yet updated to a minimum of 0.9.12.0 will then be disconnected and banned. Fixes some Windows build issues, Add option to disable blockchain auto-save (useful to reduce swapping on low-memory nodes) ,Prioritize transactions by fee/byte, Disable relay of transactions with legacy fee lower than current default
 
 #### May
 
@@ -120,13 +122,18 @@ Various portability fixes (mostly from Monero), Small reduction to memory usage 
 
 #### September
 
+  - [30] v0.9.13.0 Point release: Update for RPC users. Anyone operating an important node or mining (solo mining or operating a pool; not relevant to pool client miners) should review the new deployment notes. Numerous portability and compilation fixes (stoffu, appveyor), RPC wallet exception handling for improved reliability (upstream from XMR/QCN, sammy007), Added deployment notes in README 
+
 #### October
+
+  - [27] v0.9.14.0 Point release: This was the last release for the Legacy Aeon software. This optional enhancement release adds one new feature and one feature from upstream (Monero). The release is fully compatible and contains no significant bug fixes. As such the previous daemon and/or wallet can be used interchangeably with this one if the new features are not needed.
+The --restricted-rpc daemon option (ported from Monero by LesPristy) disables some unsafe RPC requests for use with public nodes. The --fee-multiplier simplewallet option increases all fees by a factor of 1 (default; unchanged) to 100 (recommended: 2 or 3). This can assist in getting urgent transactions confirmed when there is a tx pool backlog. May also be used when creating mixin 0 transactions to bid for the one available tx slot per block (a 0 mixin with a fee multiplier of 2 may still be less expensive and/or confirm faster than a mixin 2 with a fee multiplier of 1, depending on the details of the transaction and network conditions). Additional changes were: README cleanup (xmr-eric), Fix for incorrect hash rate displayed by daemon diff command, Added instructions for manual cmake to README
 
 #### November
 
 #### December
 
-### 2018
+## 2018
 
 #### January
 
@@ -138,48 +145,61 @@ Various portability fixes (mostly from Monero), Small reduction to memory usage 
 
 #### May
 
-  - [24] v0.12.0.0 Point Release: Merge pull request #13 from stoffu/aeon-v0.12.0-checkpoints, update checkpoints
+  - [24] Aeon Sophia Released. See all release notes [Here](https://github.com/aeonix/aeon/releases/tag/v0.12.0.0)
 
 #### June
 
-  - [3] v0.12.0.0 Sophia Rebase Release: Aeon hardfork block height 963500 to add LMDB and catch up to Monero v0.12.0.0 code. 
-  - [14] v0.12.1.0 Merge pull request #31 from stoffu/aeon-wdouble, wallet2: fix double counting outs if the tx pubkey is duplicated /monero#3985
-  - [16] v0.12.1.1 Merge pull request #32 from stoffu/aeon-bump-0.12.1.0, bump version for 0.12.1 point release
+  - [3] v0.12.0.0 Hard Fork height 963500. Aeon Rebased to Monero's latest codebase with RingCT disabled, CryptoNight-Lite variant 1, limited use of ringsize 1, ban ringsize 2. Aeon also Integrated a remake of Monero's GUI wallet with the help of (DSC) from the Monero team. 
+  
+  - [14] v0.12.1.0 Point release: Merge pull request #31 from stoffu/aeon-wdouble, wallet2: fix double counting outs if the tx pubkey is duplicated /monero#3985
+  
+  - [16] v0.12.1.1 Point release: This recommended point release fixes three wallet bugs which can result in failed transactions or missed payments under certain conditions. It also includes improved installation instructions for Ubuntu/Debian. Note: 0.12.1.1 replaces the withdrawn 0.12.1.0, which was missing an updated version string. There are no other changes. Merge pull request #32 from stoffu/aeon-bump-0.12.1.0, bump version for 0.12.1 point release
+  
   - [20] v0.12.2.0 Merge pull request #37 from stoffu/aeon-fill-template-fix, tx_pool.fill_block_template: fix miscalculation of total size and fee
-  - [20] v0.12.2.1 Merge pull request #38 from stoffu/aeon-bump-0.12.2, bump version to 0.12.2
-  - [26] v0.12.3.0 Merge pull request #40 from stoffu/aeon-bump-0.12.3, bump version to 0.12.3
+  
+  - [20] v0.12.2.1 Point Release: This point release fixes a bug in block construction resulting in lower block rewards under some conditions involving very large transactions. Recommended update for nodes running a mining pool and users who are solo mining, otherwise updating is not needed. Note: replaces withdrawn 0.12.2.0, which did not update the version string Merge pull request #38 from stoffu/aeon-bump-0.12.2, bump version to 0.12.2
+  
+  - [26] v0.12.3.0 Point release: This recommended update improves wallet handling of split transfers, resulting in smaller transactions and lower fees. Merge pull request #40 from stoffu/aeon-bump-0.12.3, bump version to 0.12.3
 
 #### July
 
-  - [7] v0.12.4.0-aeon Merge pull request #42 from stoffu/aeon-bump-0.12.4, bump version to 0.12.4
-  - [9] v0.12.5.0-aeon Merge pull request #45 from stoffu/process-outs-once, wallet2: ensure outputs are processed only once /monero#4118
-
+  - [7] v0.12.4.0 Point release: SOURCE CODE ONLY. This recommended point release further optimizes transaction size and fees by ignoring inefficient tiny dust outputs. This feature can be controlled using the ignore-fractional-outputs option (default on). Merge pull request #42 from stoffu/aeon-bump-0.12.4, bump version to 0.12.4
+  
+  - [9] v0.12.5.0 Point release: Contains additional upstream fix to ensure outputs are processed only once. Merge pull request #45 from stoffu/process-outs-once, wallet2: ensure outputs are processed only once /monero#4118
 
 #### August
 
 #### September
 
-  - [27] v0.12.6.0-aeon Merge pull request #54 from stoffu/aeon-bump-0.12.6, bump version to 0.12.6
+  - [27] v0.12.6.0 Point release: Dozens of upstream performance, reliability and security patches. Improved packaging for (unfinished/non-usable) Ledger wallet support, Several documentation improvements from the AEON community, Disable incorrect/obsolete DNS lookups. Fixed P2P network issue that prevent DoS attacks against the nodes. *All users receiving payments should update ASAP to protect against the cryptonote duplicate output coin burning attack described in https://getmonero.org/2018/09/25/a-post-mortum-of-the-burning-bug.html (if unable to update immediately, suspend receiving payments until updated).*  Merge pull request #54 from stoffu/aeon-bump-0.12.6, bump version to 0.12.6
 
 #### October
 
 #### November
 
-  - [27] v0.12.7.0-aeon Merge pull request #78 from stoffu/aeon-bump-0.12.7, bump version to 0.12.7
-  - [30] v0.12.8.0-aeon Merge pull request #78 from stoffu/aeon-bump-0.12.7, bump version to 0.12.7
+  - [27] v0.12.7.0 Point release: SOURCE CODE ONLY. Dozens of upstream performance, reliability and security patches
+Several documentation and configuration improvements from the AEON community. Daeomon update to help prevent possible database corruption and loss of synchronization with the rest of the network for P2P users. Merge pull request #78 from stoffu/aeon-bump-0.12.7, bump version to 0.12.7
+  
+  - [30] v0.12.8.0 Point release: This maintenance release fixes a problem that existed in 0.12.7.0 only when using the wallet on Windows, and in addition contains a cosmetic improvement to logging and some documentation cleanup. If you are not running Windows there is no need to update from 0.12.7.0. Note: The initial linux binary was built with an incorrect version tag. This has now been corrected. Merge pull request #78 from stoffu/aeon-bump-0.12.7, bump version to 0.12.7
 
 #### December
 
-  - [4] Community meeting
+  - [4] First Community meeting held on the Discord channel [HERE](https://github.com/AEONCommunity/CommunityMeetUps-logs/blob/master/12_4_2018%20Discord%20log.md)
 
-### 2019
+## 2019
 
 #### January
 
   - [8] Aeon added to Bisq's official release: https://github.com/bisq-network/bisq/releases/tag/v0.9.2
 
+  - [17] Community created [Tester Central repository](https://github.com/AEONCommunity/TesterCentral) for aiding in testing anything Aeon related. 
+  
 #### Feburary
 
+  - [1] First ever [Aeon Community Giveaway](https://twitter.com/AeonCommunity/status/1091515045073297409). Ledger NanoS was gifted to an Aeon community member!
+
+  - [28] Community Meeting
+  
 
 
 


### PR DESCRIPTION
Add and fix all current Aeon core release candidates since inception. Add a few Community event related additions.